### PR TITLE
Add browserslist

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,1 @@
+last 2 versions

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,7 @@ gulp.task('sass', function () {
             gutil.log(gutil.colors.red('Error (' + error.plugin + '): ' + error.messageFormatted));
         })
         .pipe(autoprefixer({
-            browsers: ['last 2 versions'],
+            // browsers are coming from browserslist file
             cascade: false
         }))
         .pipe(minifyCss())

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "node": "0.9.0"
     },
     "devDependencies": {
-        "browserslist-saucelabs": "^0.1.2",
+        "browserslist-saucelabs": "0.1.2",
         "gulp": "3.9.0",
         "gulp-autoprefixer": "2.3.1",
         "gulp-minify-css": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "node": "0.9.0"
     },
     "devDependencies": {
+        "browserslist-saucelabs": "^0.1.2",
         "gulp": "3.9.0",
         "gulp-autoprefixer": "2.3.1",
         "gulp-minify-css": "1.2.0",

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -10,5 +10,6 @@ module.exports = {
         ].join(' ');
     },
 
+    // browsers are coming from the browserslist file
     sauceLabsBrowsers: b2s()
 };

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -1,3 +1,5 @@
+var b2s = require('browserslist-saucelabs');
+
 module.exports = {
     formatTaskName: function formatTaskName (browserName) {
         return [
@@ -8,18 +10,5 @@ module.exports = {
         ].join(' ');
     },
 
-    sauceLabsBrowsers: {
-        sl_ie_9: {
-            base: 'SauceLabs',
-            browserName: 'internet explorer',
-            platform: 'Windows 7',
-            version: '9.0'
-        },
-        sl_firefox: {
-            base: 'SauceLabs',
-            browserName: 'firefox',
-            platform: 'Windows 8',
-            version: '38'
-        }
-    }
+    sauceLabsBrowsers: b2s()
 };

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -17,7 +17,11 @@ module.exports = function (config) {
     // Browsers to run on Sauce Labs
     // Check out https://saucelabs.com/platforms for all browser/OS combos
     if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
-        browsers = baseConf.sauceLabsBrowsers;
+        browsers = baseConf.sauceLabsBrowsers.reduce(function (browsers, capability) {
+            browsers[JSON.stringify(capability)] = capability;
+            browsers[JSON.stringify(capability)].base = 'SauceLabs';
+            return browsers;
+        }, {});
     }
 
     var settings = {

--- a/tests/protractor.conf.js
+++ b/tests/protractor.conf.js
@@ -33,8 +33,8 @@ if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
     config.capabilities = null;
     config.sauceUser = process.env.SAUCE_USERNAME;
     config.sauceKey = process.env.SAUCE_ACCESS_KEY;
-    config.multiCapabilities = Object.keys(browsers).map(function (key) {
-        var browserCapability =  browsers[key];
+    config.multiCapabilities = browsers.map(function (browser) {
+        var browserCapability =  browser;
         browserCapability.name = formatTaskName(browserCapability.browserName);
         return browserCapability;
     });


### PR DESCRIPTION
browserslist is a file that contains the list of browsers in free format that is then used
by autoprefixer and saucelabs.

Useful links:
https://github.com/ai/browserslist
https://github.com/vxsx/browserslist-saucelabs

Travis log looks kind of crazy, but saucelabs report normal amount of tests run