### PR TITLE
don't rebase paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,10 @@ gulp.task('sass', function () {
             // browsers are coming from browserslist file
             cascade: false
         }))
-        .pipe(minifyCss())
+        .pipe(minifyCss({
+            // fixes font imports from google fonts
+            rebase: false
+        }))
         .pipe(sourcemaps.write())
         .pipe(gulp.dest(PROJECT_PATH.css));
 });


### PR DESCRIPTION
before:
<img width="753" alt="screen shot 2015-10-10 at 18 10 23" src="https://cloud.githubusercontent.com/assets/366813/10416163/9abe0e00-700a-11e5-850d-2dbce442a9f8.png">

after:
no error

we should remove it after this one is fixed https://github.com/jakubpawlowicz/clean-css/issues/679